### PR TITLE
Unbreak the nightly build

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -22,7 +22,7 @@ npm install
 cp ./built/local/* ./bin/
 
 # Copy the source TypeScript compiler and services, but not the tsconfig.json files
-cp ./src/compiler/* ../src/compiler
+cp -r ./src/compiler/* ../src/compiler
 cp -r ./src/services/* ../src/services
 rm ../src/services/tsconfig.json ../src/compiler/tsconfig.json
 


### PR DESCRIPTION
Typescript now has a `transformers` directory in `./src/compiler` which caused the `cp` command to exit with message `cp: omitting directory`./src/compiler/transformers'` and exit code 1. The fix is to add -r flag to make it copy directories recursively.
